### PR TITLE
[27470731] Consume topics from CDN/SlackbotAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "rxjs": "^7.2.0"
   },
   "devDependencies": {
+    "@nestjs/axios": "^2.0.0",
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",
@@ -39,6 +40,7 @@
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
+    "axios": "^1.4.0",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,10 +5,11 @@ import { RendererController } from './common/controllers/renderer/renderer.contr
 import { RendererService } from './common/services/renderer/renderer.service';
 import { ConfigModule } from '@nestjs/config';
 import { HttpModule } from "@nestjs/axios";
+import { SirvCdnService } from './common/services/sirv-cdn/sirv-cdn.service';
 
 @Module({
   imports: [ConfigModule.forRoot(), HttpModule],
   controllers: [AppController, RendererController],
-  providers: [AppService, RendererService],
+  providers: [AppService, RendererService, SirvCdnService],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,10 +6,11 @@ import { RendererService } from './common/services/renderer/renderer.service';
 import { ConfigModule } from '@nestjs/config';
 import { HttpModule } from "@nestjs/axios";
 import { SirvCdnService } from './common/services/sirv-cdn/sirv-cdn.service';
+import { SlackBotApiService } from './common/services/slack-bot-api/slack-bot-api.service';
 
 @Module({
   imports: [ConfigModule.forRoot(), HttpModule],
   controllers: [AppController, RendererController],
-  providers: [AppService, RendererService, SirvCdnService],
+  providers: [AppService, RendererService, SirvCdnService, SlackBotApiService],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,10 @@ import { AppService } from './app.service';
 import { RendererController } from './common/controllers/renderer/renderer.controller';
 import { RendererService } from './common/services/renderer/renderer.service';
 import { ConfigModule } from '@nestjs/config';
+import { HttpModule } from "@nestjs/axios";
 
 @Module({
-  imports: [ConfigModule.forRoot()],
+  imports: [ConfigModule.forRoot(), HttpModule],
   controllers: [AppController, RendererController],
   providers: [AppService, RendererService],
 })

--- a/src/common/controllers/renderer/renderer.controller.ts
+++ b/src/common/controllers/renderer/renderer.controller.ts
@@ -38,7 +38,7 @@ export class RendererController {
 
     const topicImages = await firstValueFrom(this.rendererService.getImagesForTopic(query.topic));
     for (const { fileName, x, y, width, height } of topicImages) {
-      const image = await loadImage(`${this.configService.get('CDN_URL')}/Images/${fileName}`);
+      const image = await loadImage(`${this.configService.get('CDN_URL')}/Images/topics/${query.topic}/${fileName}`);
       context.drawImage(image, x, y, width, height);
     }
 

--- a/src/common/controllers/renderer/renderer.controller.ts
+++ b/src/common/controllers/renderer/renderer.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, StreamableFile, Header, Query } from '@nestjs/common';
 import { createCanvas, loadImage } from '@napi-rs/canvas';
 import { RendererService } from '../../services/renderer/renderer.service';
 import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
 
 @Controller('renderer')
 export class RendererController {
@@ -35,7 +36,7 @@ export class RendererController {
 
     context.drawImage(background, 0, 0, 1920, 1080);
 
-    const topicImages = this.rendererService.getImagesForTopic(query.topic);
+    const topicImages = await firstValueFrom(this.rendererService.getImagesForTopic(query.topic));
     for (const { imageKey, x, y, width, height } of topicImages) {
       const image = await loadImage(`${this.configService.get('CDN_URL')}/Images/${imageKey}`);
       context.drawImage(image, x, y, width, height);

--- a/src/common/controllers/renderer/renderer.controller.ts
+++ b/src/common/controllers/renderer/renderer.controller.ts
@@ -37,8 +37,8 @@ export class RendererController {
     context.drawImage(background, 0, 0, 1920, 1080);
 
     const topicImages = await firstValueFrom(this.rendererService.getImagesForTopic(query.topic));
-    for (const { imageKey, x, y, width, height } of topicImages) {
-      const image = await loadImage(`${this.configService.get('CDN_URL')}/Images/${imageKey}`);
+    for (const { fileName, x, y, width, height } of topicImages) {
+      const image = await loadImage(`${this.configService.get('CDN_URL')}/Images/${fileName}`);
       context.drawImage(image, x, y, width, height);
     }
 

--- a/src/common/services/renderer/renderer.service.ts
+++ b/src/common/services/renderer/renderer.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import ImageData from '../../types/ImageData';
 import { SirvCdnService } from '../sirv-cdn/sirv-cdn.service';
-import { Observable, map, of, switchMap } from 'rxjs';
+import { Observable, map, switchMap } from 'rxjs';
 import { SlackBotApiService } from '../slack-bot-api/slack-bot-api.service';
 
 @Injectable()

--- a/src/common/services/renderer/renderer.service.ts
+++ b/src/common/services/renderer/renderer.service.ts
@@ -8,7 +8,7 @@ export class RendererService {
   constructor(private readonly sirvCdnService: SirvCdnService) { }
 
   genericTitle = 'Congratulations!';
-  topicImages = [
+  topicImages: Partial<ImageData>[] = [
     {
       fileName: 'cake.png',
       x: 120,

--- a/src/common/services/renderer/renderer.service.ts
+++ b/src/common/services/renderer/renderer.service.ts
@@ -12,13 +12,6 @@ export class RendererService {
   ) { }
 
   genericTitle = 'Congratulations!';
-  topicImages: Partial<ImageData>[] = [
-    {
-      fileName: 'cake.png',
-      x: 120,
-      y: 80,
-    }
-  ];
   charactersPerLine = 40;
   maxSubtitleLength = 200;
 
@@ -52,9 +45,9 @@ export class RendererService {
         const fileNames = cdnImages.map(({ filename }) => filename);
         return this.slackBotApiService.getImagesData(fileNames)
           .pipe(
-            map(({ data }) => {
+            map(imagesData => {
               return cdnImages.map(({ filename, meta }) => {
-                const file = data.find(({ fileName }) => fileName === filename);
+                const file = imagesData.find(({ fileName }) => fileName === filename);
                 return { ...file, width: meta.width, height: meta.height };
               });
             }))

--- a/src/common/services/renderer/renderer.service.ts
+++ b/src/common/services/renderer/renderer.service.ts
@@ -1,8 +1,11 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import ImageData from '../../types/ImageData';
+import { SirvCdnService } from '../sirv-cdn/sirv-cdn.service';
 
 @Injectable()
 export class RendererService {
+  constructor(private readonly sirvCdnService: SirvCdnService) { }
+
   genericTitle = 'Congratulations!';
   topicImages = {
     birthday: [
@@ -48,7 +51,7 @@ export class RendererService {
   }
 
   getImagesForTopic(topic: string): ImageData[] {
-    // return this.topicImages[topic] || [];
-    `https://api.sirv.com/v2/files/readdir?dirname=/Images/${topic}`
+    this.sirvCdnService.getTopicImages(topic).subscribe(response => console.log(response.data));
+    return this.topicImages[topic] || [];
   }
 }

--- a/src/common/services/renderer/renderer.service.ts
+++ b/src/common/services/renderer/renderer.service.ts
@@ -48,6 +48,7 @@ export class RendererService {
   }
 
   getImagesForTopic(topic: string): ImageData[] {
-    return this.topicImages[topic] || [];
+    // return this.topicImages[topic] || [];
+    `https://api.sirv.com/v2/files/readdir?dirname=/Images/${topic}`
   }
 }

--- a/src/common/services/renderer/renderer.service.ts
+++ b/src/common/services/renderer/renderer.service.ts
@@ -48,13 +48,13 @@ export class RendererService {
 
   getImagesForTopic(topic: string): Observable<ImageData[]> {
     return this.sirvCdnService.getTopicImages(topic).pipe(
-      switchMap(({ data: cdnImages }) => {
+      switchMap(cdnImages => {
         const fileNames = cdnImages.map(({ filename }) => filename);
         return this.slackBotApiService.getImagesData(fileNames)
           .pipe(
-            map(({ data: imagesData }) => {
+            map(({ data }) => {
               return cdnImages.map(({ filename, meta }) => {
-                const file = imagesData.find(({ fileName }) => fileName === filename);
+                const file = data.find(({ fileName }) => fileName === filename);
                 return { ...file, width: meta.width, height: meta.height };
               });
             }))

--- a/src/common/services/sirv-cdn/sirv-cdn.service.ts
+++ b/src/common/services/sirv-cdn/sirv-cdn.service.ts
@@ -2,7 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import SirvCdnTokenResponse from '../../types/SirvCdnTokenResponse';
-import { Observable, map } from 'rxjs';
+import { Observable, map, tap } from 'rxjs';
 import { AxiosResponse } from 'axios';
 
 interface FolderContentsCdnResponse {
@@ -20,34 +20,44 @@ interface FileMetaData {
 
 @Injectable()
 export class SirvCdnService {
-  constructor(private configService: ConfigService, private readonly httpService: HttpService) {
-    httpService.axiosRef.interceptors.response.use(config => {
-      console.log('getTokenCdn', this.token);
-      return {
-        ...config,
-        headers: { ...config.headers, Authorization: `Bearer ${this.token}` }
+  constructor(private configService: ConfigService) {
+    this.httpService = new HttpService();
+    this.httpService.axiosRef.interceptors.request.use(config => {
+      if (config.url.includes(this.configService.get('CDN_API_URL'))) {
+        console.log('cdn request');
+        return {
+          ...config,
+          headers: { ...config.headers, Authorization: `Bearer ${this.token}` }
+        }
       }
+      return config;
     });
-    httpService.axiosRef.interceptors.response.use(
+    this.httpService.axiosRef.interceptors.response.use(
       response => {
         return response;
       },
       async error => {
-        console.log('errorcdn');
         const originalConfig = error.config;
-        if (error.response.status === 401 && !originalConfig._retry) {
-          originalConfig._retry = true;
-          const { token } = await this.refreshToken();
-          this.token = token;
-          console.log('setTokenCdn', this.token);
-          originalConfig.headers.Authorization = `Bearer ${token}`;
-          return httpService.axiosRef(originalConfig);
+        if (originalConfig.url.includes(this.configService.get('CDN_API_URL'))) {
+          console.log('cdn fail 1');
+          if (error.response.status === 401 && !originalConfig._retry) {
+            console.log('cdn fail 2');
+            originalConfig._retry = true;
+            const { token } = await this.refreshToken();
+            this.token = token;
+            console.log('setTokenCdn', this.token);
+            originalConfig.headers.Authorization = `Bearer ${token}`;
+            return this.httpService.axiosRef(originalConfig);
+          }
+          return Promise.reject(error);
         }
+        return Promise.reject(error);
       });
   }
 
   baseUrl = this.configService.get('CDN_API_URL');
   token = '';
+  httpService = null;
 
   async refreshToken(): Promise<SirvCdnTokenResponse> {
     return this.httpService.axiosRef.post(`${this.baseUrl}/token`, {
@@ -57,8 +67,9 @@ export class SirvCdnService {
       .then(response => response.data);
   }
 
-  getTopicImages(topic: string): Observable<AxiosResponse<FileDataCdn[]>> {
+  getTopicImages(topic: string): Observable<FileDataCdn[]> {
     return this.httpService.get(`${this.baseUrl}/files/readdir?dirname=/Images/topics/${topic}`)
-      .pipe(map(({ data }) => data.contents));
+      .pipe(
+        map(({ data }) => data.contents));
   }
 }

--- a/src/common/services/sirv-cdn/sirv-cdn.service.ts
+++ b/src/common/services/sirv-cdn/sirv-cdn.service.ts
@@ -60,7 +60,6 @@ export class SirvCdnService {
 
   getTopicImages(topic: string): Observable<FileDataCdn[]> {
     return this.httpService.get(`${this.baseUrl}/files/readdir?dirname=/Images/topics/${topic}`)
-      .pipe(
-        map(({ data }) => data.contents));
+      .pipe(map(({ data }) => data.contents));
   }
 }

--- a/src/common/services/sirv-cdn/sirv-cdn.service.ts
+++ b/src/common/services/sirv-cdn/sirv-cdn.service.ts
@@ -1,0 +1,20 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AxiosResponse } from 'axios';
+import { Observable } from 'rxjs';
+import SirvCdnTokenResponse from '../../types/SirvCdnTokenResponse';
+
+@Injectable()
+export class SirvCdnService {
+  constructor(private configService: ConfigService, private readonly httpService: HttpService) { }
+
+  baseUrl = this.configService.get('CDN_API_URL');
+
+  getToken(): Observable<AxiosResponse<SirvCdnTokenResponse>> {
+    return this.httpService.post(`${this.baseUrl}/token`, {
+      clientId: this.configService.get('CDN_CLIENT_ID'),
+      clientSecret: this.configService.get('CDN_CLIENT_SECRET')
+    })
+  }
+}

--- a/src/common/services/sirv-cdn/sirv-cdn.service.ts
+++ b/src/common/services/sirv-cdn/sirv-cdn.service.ts
@@ -7,14 +7,44 @@ import SirvCdnTokenResponse from '../../types/SirvCdnTokenResponse';
 
 @Injectable()
 export class SirvCdnService {
-  constructor(private configService: ConfigService, private readonly httpService: HttpService) { }
+  constructor(private configService: ConfigService, private readonly httpService: HttpService) {
+    httpService.axiosRef.interceptors.response.use(config => {
+      console.log('getToken', this.token);
+      return {
+        ...config,
+        headers: { ...config.headers, Authorization: `Bearer ${this.token}` }
+      }
+    });
+    httpService.axiosRef.interceptors.response.use(
+      response => {
+        return response;
+      },
+      async error => {
+        console.log('error', error);
+        const originalConfig = error.config;
+        if (error.response.status === 401 && !originalConfig._retry) {
+          originalConfig._retry = true;
+          const { token } = await this.refreshToken();
+          this.token = token;
+          console.log('setToken', this.token);
+          originalConfig.headers.Authorization = `Bearer ${token}`;
+          return httpService.axiosRef(originalConfig);
+        }
+      });
+  }
 
   baseUrl = this.configService.get('CDN_API_URL');
+  token = '';
 
-  getToken(): Observable<AxiosResponse<SirvCdnTokenResponse>> {
-    return this.httpService.post(`${this.baseUrl}/token`, {
+  refreshToken(): Promise<SirvCdnTokenResponse> {
+    return this.httpService.axiosRef.post(`${this.baseUrl}/token`, {
       clientId: this.configService.get('CDN_CLIENT_ID'),
       clientSecret: this.configService.get('CDN_CLIENT_SECRET')
     })
+      .then(response => response.data);
+  }
+
+  getTopicImages(topic: string) {
+    return this.httpService.get(`${this.baseUrl}/files/readdir?dirname=/Images/topics/${topic}`)
   }
 }

--- a/src/common/services/sirv-cdn/sirv-cdn.service.ts
+++ b/src/common/services/sirv-cdn/sirv-cdn.service.ts
@@ -1,21 +1,8 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import SirvCdnTokenResponse from '../../types/SirvCdnTokenResponse';
-import { Observable, map, tap } from 'rxjs';
-
-interface FolderContentsCdnResponse {
-  contents: FileDataCdn
-}
-interface FileDataCdn {
-  filename: string;
-  meta: FileMetaData;
-}
-
-interface FileMetaData {
-  width: number;
-  height: number;
-}
+import { SirvCdnTokenResponse, SirvCdnFileData } from './sirv-cdn.types'
+import { Observable, map } from 'rxjs';
 
 @Injectable()
 export class SirvCdnService {
@@ -58,7 +45,7 @@ export class SirvCdnService {
       .then(response => response.data);
   }
 
-  getTopicImages(topic: string): Observable<FileDataCdn[]> {
+  getTopicImages(topic: string): Observable<SirvCdnFileData[]> {
     return this.httpService.get(`${this.baseUrl}/files/readdir?dirname=/Images/topics/${topic}`)
       .pipe(map(({ data }) => data.contents));
   }

--- a/src/common/services/sirv-cdn/sirv-cdn.types.ts
+++ b/src/common/services/sirv-cdn/sirv-cdn.types.ts
@@ -1,0 +1,16 @@
+interface SirvCdnTokenResponse {
+  token: string;
+  expiresIn: number;
+}
+
+interface SirvCdnFileData {
+  filename: string;
+  meta: FileMetaData;
+}
+
+interface FileMetaData {
+  width: number;
+  height: number;
+}
+
+export { SirvCdnFileData, SirvCdnTokenResponse };

--- a/src/common/services/slack-bot-api/slack-bot-api.service.ts
+++ b/src/common/services/slack-bot-api/slack-bot-api.service.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { AxiosResponse } from 'axios';
 import { Observable } from 'rxjs';
 
 interface ImageDataAPI {
@@ -16,10 +16,7 @@ export class SlackBotApiService {
   constructor(private configService: ConfigService, private readonly httpService: HttpService) {
     this.httpService.axiosRef.interceptors.request.use(config => {
       if (config.url.includes(this.configService.get('SLACKBOT_API_URL'))) {
-        return {
-          ...config,
-          headers: { ...config.headers, Authorization: `Bearer ${this.token}` }
-        } as InternalAxiosRequestConfig;
+        config.headers.Authorization = `Bearer ${this.token}`
       }
       return config;
     }
@@ -30,15 +27,16 @@ export class SlackBotApiService {
       },
       async error => {
         const originalConfig = error.config;
-        if (originalConfig.url.includes(this.configService.get('SLACKBOT_API_URL'))) {
-          if (error.response.status === 401 && !originalConfig._retry) {
-            originalConfig._retry = true;
-            const { token } = await this.refreshToken();
-            this.token = token;
-            originalConfig.headers.Authorization = `Bearer ${token}`;
-            return this.httpService.axiosRef(originalConfig);
-          }
-          return Promise.reject(error);
+        if (
+          originalConfig.url.includes(this.configService.get('SLACKBOT_API_URL')) &&
+          error.response.status === 401 &&
+          !originalConfig._retry
+        ) {
+          originalConfig._retry = true;
+          const { token } = await this.refreshToken();
+          this.token = token;
+          originalConfig.headers.Authorization = `Bearer ${token}`;
+          return this.httpService.axiosRef(originalConfig);
         }
         return Promise.reject(error);
       });

--- a/src/common/services/slack-bot-api/slack-bot-api.service.ts
+++ b/src/common/services/slack-bot-api/slack-bot-api.service.ts
@@ -1,8 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { AxiosResponse } from 'axios';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 interface ImageDataAPI {
   id: number;
@@ -53,8 +52,9 @@ export class SlackBotApiService {
       .then(response => response.data);
   }
 
-  getImagesData(fileNames: string[]): Observable<AxiosResponse<ImageDataAPI[]>> {
+  getImagesData(fileNames: string[]): Observable<ImageDataAPI[]> {
     const fileNamesString = fileNames.join(',');
     return this.httpService.get(`${this.baseUrl}/image/names/${fileNamesString}`)
+      .pipe(map(({ data }) => data));
   }
 }

--- a/src/common/services/slack-bot-api/slack-bot-api.service.ts
+++ b/src/common/services/slack-bot-api/slack-bot-api.service.ts
@@ -1,0 +1,59 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AxiosResponse } from 'axios';
+import { Observable } from 'rxjs';
+
+interface ImageDataAPI {
+  id: number;
+  fileName: string;
+  x: number;
+  y: number;
+}
+
+@Injectable()
+export class SlackBotApiService {
+  constructor(private configService: ConfigService, private readonly httpService: HttpService) {
+    this.h1 = httpService;
+    this.h1.axiosRef.interceptors.response.use(config => {
+      console.log('getTokenSlack', this.token);
+      return {
+        ...config,
+        headers: { ...config.headers, Authorization: `Bearer ${this.token}` }
+      }
+    });
+    this.h1.axiosRef.interceptors.response.use(
+      response => {
+        return response;
+      },
+      async error => {
+        console.log('errorslack');
+        const originalConfig = error.config;
+        if (error.response.status === 401 && !originalConfig._retry) {
+          originalConfig._retry = true;
+          const { token } = await this.refreshToken();
+          this.token = token;
+          console.log('setTokenSlack', this.token);
+          originalConfig.headers.Authorization = `Bearer ${token}`;
+          return this.h1.axiosRef(originalConfig);
+        }
+      });
+  }
+
+  baseUrl = this.configService.get('SLACKBOT_API_URL');
+  token = '';
+  h1 = null;
+
+  async refreshToken(): Promise<{ token: string }> {
+    return this.h1.axiosRef.post(`${this.baseUrl}/auth/signin`, {
+      email: 'test@test.com',
+      password: 'password'
+    })
+      .then(response => response.data);
+  }
+
+  getImagesData(fileNames: string[]): Observable<AxiosResponse<ImageDataAPI[]>> {
+    const fileNamesString = fileNames.join(',');
+    return this.h1.get(`${this.baseUrl}/image/names/${fileNamesString}`)
+  }
+}

--- a/src/common/services/slack-bot-api/slack-bot-api.service.ts
+++ b/src/common/services/slack-bot-api/slack-bot-api.service.ts
@@ -2,13 +2,7 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Observable, map } from 'rxjs';
-
-interface ImageDataAPI {
-  id: number;
-  fileName: string;
-  x: number;
-  y: number;
-}
+import { SlackBotApiTokenResponse, SlackBotApiImageData } from './slack-bot-api.types';
 
 @Injectable()
 export class SlackBotApiService {
@@ -44,15 +38,15 @@ export class SlackBotApiService {
   baseUrl = this.configService.get('SLACKBOT_API_URL');
   token = '';
 
-  async refreshToken(): Promise<{ token: string }> {
+  async refreshToken(): Promise<SlackBotApiTokenResponse> {
     return this.httpService.axiosRef.post(`${this.baseUrl}/auth/signin`, {
-      email: 'test@test.com',
-      password: 'password'
+      email: this.configService.get('SLACKBOT_API_EMAIL'),
+      password: this.configService.get('SLACKBOT_API_PASSWORD')
     })
       .then(response => response.data);
   }
 
-  getImagesData(fileNames: string[]): Observable<ImageDataAPI[]> {
+  getImagesData(fileNames: string[]): Observable<SlackBotApiImageData[]> {
     const fileNamesString = fileNames.join(',');
     return this.httpService.get(`${this.baseUrl}/image/names/${fileNamesString}`)
       .pipe(map(({ data }) => data));

--- a/src/common/services/slack-bot-api/slack-bot-api.types.ts
+++ b/src/common/services/slack-bot-api/slack-bot-api.types.ts
@@ -1,0 +1,12 @@
+interface SlackBotApiTokenResponse {
+  token: string;
+}
+
+interface SlackBotApiImageData {
+  id: number;
+  fileName: string;
+  x: number;
+  y: number;
+}
+
+export { SlackBotApiTokenResponse, SlackBotApiImageData };

--- a/src/common/types/ImageData.ts
+++ b/src/common/types/ImageData.ts
@@ -1,5 +1,5 @@
 export default interface ImageData {
-  imageKey: string;
+  fileName: string;
   x: number;
   y: number;
   width: number;

--- a/src/common/types/SirvCdnTokenResponse.ts
+++ b/src/common/types/SirvCdnTokenResponse.ts
@@ -1,0 +1,4 @@
+export default interface SirvCdnTokenResponse {
+  token: string;
+  expiresIn: number;
+}

--- a/src/common/types/SirvCdnTokenResponse.ts
+++ b/src/common/types/SirvCdnTokenResponse.ts
@@ -1,4 +1,0 @@
-export default interface SirvCdnTokenResponse {
-  token: string;
-  expiresIn: number;
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,6 @@ if (
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(3001);
 }
 bootstrap();

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,6 +749,11 @@
     "@napi-rs/canvas-linux-x64-musl" "0.1.40"
     "@napi-rs/canvas-win32-x64-msvc" "0.1.40"
 
+"@nestjs/axios@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-2.0.0.tgz#2116fad483e232ef102a877b503a9f19926bd102"
+  integrity sha512-F6oceoQLEn031uun8NiommeMkRIojQqVryxQy/mK7fx0CI0KbgkJL3SloCQcsOD+agoEnqKJKXZpEvL6FNswJg==
+
 "@nestjs/cli@^9.0.0":
   version "9.4.2"
   resolved "https://registry.npmjs.org/@nestjs/cli/-/cli-9.4.2.tgz"
@@ -1510,6 +1515,15 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.5.0:
   version "29.5.0"
@@ -2489,6 +2503,11 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 fork-ts-checker-webpack-plugin@8.0.0:
   version "8.0.0"
@@ -3991,6 +4010,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Added logic to call CDN to get all files from a topic
- Added logic to call SlackBot service to get all metadata (x, y position) for each image name retrieved in the CDN
- Render images based on data obtained from both sources